### PR TITLE
implement entity and repo for risk score service

### DIFF
--- a/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/dto/RiskResponseDTO.java
+++ b/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/dto/RiskResponseDTO.java
@@ -17,7 +17,7 @@ public class RiskResponseDTO {
     private Long customerId;
     private Integer score;             // 0-100
     private String category;           // LOW/MEDIUM/HIGH
-    //private String modelVersion;
+    private String modelVersion;
     private LocalDateTime calculatedAt;
 
     private List<String> reasons;

--- a/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/entity/RiskHistory.java
+++ b/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/entity/RiskHistory.java
@@ -1,4 +1,52 @@
 package com.fraud.risk_score_service.entity;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="risk_history")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class RiskHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long riskHistoryId;
+
+    @Column(nullable = false)
+    private Long customerId;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(nullable = false, length = 16)
+    private String category;
+
+    private Integer previousScore;
+    private String previousCategory;
+
+    @Column(nullable = false)
+    private LocalDateTime calculatedAt;
+
+    @Column(nullable = false, length = 32)
+    private String trigger; // TRANSACTION/DAILY_BATCH/MANUAL
+
+    private String modelVersion;
+
+    private Boolean alertTriggered;
+
+    @Column(columnDefinition = "TEXT")
+    private String featureSnapshotJson;
+
+    @Column(columnDefinition = "TEXT")
+    private String reasonsJson;
 }
+
+

--- a/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/entity/RiskScore.java
+++ b/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/entity/RiskScore.java
@@ -1,9 +1,13 @@
 package com.fraud.risk_score_service.entity;
 
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "risk_scores")
@@ -13,5 +17,19 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 public class RiskScore {
+
+    @Id
+    private Long customerId;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(nullable = false,length = 20)
+    private String category;
+
+    private String modelVersion;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
 }
-`

--- a/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/repository/RiskHistoryRepository.java
+++ b/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/repository/RiskHistoryRepository.java
@@ -1,4 +1,10 @@
 package com.fraud.risk_score_service.repository;
 
-public class RiskHistoryRepository {
+import com.fraud.risk_score_service.entity.RiskHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RiskHistoryRepository extends JpaRepository<RiskHistory,Long> {
+
 }

--- a/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/repository/RiskScoreRepository.java
+++ b/backend/risk-score-service/src/main/java/com/fraud/risk_score_service/repository/RiskScoreRepository.java
@@ -1,4 +1,10 @@
 package com.fraud.risk_score_service.repository;
 
-public class RiskScoreRepository {
+import org.springframework.stereotype.Repository;
+import com.fraud.risk_score_service.entity.RiskScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@Repository
+public interface RiskScoreRepository extends JpaRepository<RiskScore,Long> {
+
 }


### PR DESCRIPTION
This pull request adds database support to the Risk Score Service by introducing the RiskHistory entity and its corresponding JPA repository. This allows the system to persist and track all risk evaluation results.